### PR TITLE
Fix .main-trackInfo-artists not targetting the correct element

### DIFF
--- a/now-playing-release-date/NowPlayingReleaseDate.js
+++ b/now-playing-release-date/NowPlayingReleaseDate.js
@@ -1,5 +1,5 @@
 console.log('Now Playing Release Date loaded');
-if (!localStorage.getItem('position')) localStorage.setItem('position', '.main-trackInfo-artists');
+if (!localStorage.getItem('position')) localStorage.setItem('position', '.w_TTPh4y9H1YD6UrTMHa.r6Psl2_K_0vpdX6vFLQd');
 setTimeout(() => initialize(), 2000);
 
 async function initialize() {


### PR DESCRIPTION
For context - seemingly after a Spotify update, .main-trackInfo-artists is not used for the currently playing song artist list (noticed since a plugin adding the next song as well still uses this class, and the date was misplaced). Replaced with classes that work, although might change in the future after a Spotify update.